### PR TITLE
Adds copyright and Amazon disclaimer notice to footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -16,7 +16,12 @@
   </div><!-- #content.site-content -->
 </div><!-- #page.site -->
 
-<footer></footer>
+<footer>
+  <small id="copyright">&copy; Copyright 2018 - <?php echo date('Y'); ?> - Fienen LLC</small>
+  <small id="disclaimer">
+    The Drunken UX Podcast is a product of Fienen, LLC The Drunken UX Podcast is a participant in the Amazon Services LLC Associates Program, an affiliate advertising program designed to provide a means for sites to earn advertising fees by advertising and linking to amazon.com.
+  </small>
+</footer>
 
 <?php wp_footer(); ?>
 


### PR DESCRIPTION
Closes #1

Some cursory research about the correct semantic tag to use for these
kinds of notices suggested using the <small> tag, suitable for "small
print" such as copyright notices and disclaimers.

I threw some id attributes on it so we can style it later.